### PR TITLE
New EEex Feature: Add deferred AfterListsResolved Lua hook

### DIFF
--- a/EEex-v2.6.6.0/headers/EEex-v2.6.6.0/EEex.h
+++ b/EEex-v2.6.6.0/headers/EEex-v2.6.6.0/EEex.h
@@ -118,6 +118,7 @@ namespace EEex {
 	void Opcode_Hook_OnCopy(CGameEffect* pSrcEffect, CGameEffect* pDstEffect);
 	void Opcode_Hook_OnDestruct(CGameEffect* pEffect);
 	void Opcode_Hook_AfterListsResolved(CGameSprite* pSprite);
+	void Opcode_Hook_FlushDeferredAfterListsResolved(CGameSprite* pSprite);
 
 	////////////
 	// Sprite //

--- a/EEex-v2.6.6.0/headers/EEex-v2.6.6.0_generated/Baldur-v2.6.6.0_generated.h
+++ b/EEex-v2.6.6.0/headers/EEex-v2.6.6.0_generated/Baldur-v2.6.6.0_generated.h
@@ -4885,6 +4885,7 @@ namespace EEex
 	extern byte CGameSprite_Hit_Roll;
 	extern bool AIBase_LuaHook_OnEventTriggerSet_Enabled;
 	extern bool Opcode_LuaHook_AfterListsResolved_Enabled;
+	extern bool Opcode_LuaHook_DeferredAfterListsResolved_Enabled;
 	extern bool Projectile_LuaHook_GlobalMutators_Enabled;
 	extern bool StutterDetector_Enabled;
 	extern int UncapFPS_BusyWaitThreshold;

--- a/EEex-v2.6.6.0/scripts/generate_bindings/in/bindings.txt
+++ b/EEex-v2.6.6.0/scripts/generate_bindings/in/bindings.txt
@@ -116,6 +116,7 @@ namespace EEex
 	// Globals
 	bool AIBase_LuaHook_OnEventTriggerSet_Enabled;
 	bool Opcode_LuaHook_AfterListsResolved_Enabled;
+	bool Opcode_LuaHook_DeferredAfterListsResolved_Enabled;
 	bool Projectile_LuaHook_GlobalMutators_Enabled;
 	bool StutterDetector_Enabled;
 	int UncapFPS_BusyWaitThreshold;

--- a/EEex-v2.6.6.0/source/EEex-v2.6.6.0/EEex.cpp
+++ b/EEex-v2.6.6.0/source/EEex-v2.6.6.0/EEex.cpp
@@ -145,6 +145,7 @@ struct ExSpriteData {
 
 	EngineVal<CVidBitmap> combatRoundsOverride[5]{};
 	Array<int, 3> oldDisabledSpellTypes;
+	bool deferredAfterListsResolvedPending = false;
 	int oldDisableSpells = 0;
 	uint64_t uuid = 0;
 
@@ -3837,6 +3838,13 @@ void EEex::Opcode_Hook_AfterListsResolved(CGameSprite* pSprite) {
 	CDerivedStats& stats = *pSprite->GetActiveStats();
 	lua_State *const L = luaState();
 
+	if (EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled) {
+		// The engine can resolve the same sprite's effect lists many times in a
+		// tick. Defer opt-in Lua listeners to the sprite's real AI pass, where
+		// this bit is consumed and collapsed to one Lua call.
+		exData.deferredAfterListsResolvedPending = true;
+	}
+
 	if
 	(
 		stats.m_disableSpells != exData.oldDisableSpells
@@ -3864,6 +3872,37 @@ void EEex::Opcode_Hook_AfterListsResolved(CGameSprite* pSprite) {
 	luaCallProtected(L, 1, 0, [&](int _) {
 		lua_getglobal(L, "EEex_Opcode_LuaHook_AfterListsResolved"); // 1 [ ..., EEex_Opcode_LuaHook_AfterListsResolved ]
 		tolua_pushusertype(L, pSprite, "CGameSprite");              // 2 [ ..., EEex_Opcode_LuaHook_AfterListsResolved, pSpriteUD ]
+	});
+
+	STUTTER_LOG_END
+}
+
+void EEex::Opcode_Hook_FlushDeferredAfterListsResolved(CGameSprite* pSprite) {
+
+	STUTTER_LOG_START(void, "EEex::Opcode_Hook_FlushDeferredAfterListsResolved")
+
+	if (!EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled) {
+		return;
+	}
+
+	auto itr = exSpriteDataMap.find(pSprite);
+	if (itr == exSpriteDataMap.end()) {
+		return;
+	}
+
+	ExSpriteData& exData = itr->second;
+	if (!exData.deferredAfterListsResolvedPending) {
+		return;
+	}
+
+	// Clear before entering Lua. If the callback causes another list
+	// resolution, the new pending bit survives for the next ProcessAI() pass.
+	exData.deferredAfterListsResolvedPending = false;
+
+	lua_State *const L = luaState();
+	luaCallProtected(L, 1, 0, [&](int _) {
+		lua_getglobal(L, "EEex_Opcode_LuaHook_DeferredAfterListsResolved"); // 1 [ ..., EEex_Opcode_LuaHook_DeferredAfterListsResolved ]
+		tolua_pushusertype(L, pSprite, "CGameSprite");                      // 2 [ ..., EEex_Opcode_LuaHook_DeferredAfterListsResolved, pSpriteUD ]
 	});
 
 	STUTTER_LOG_END
@@ -5361,6 +5400,7 @@ void EEex::InitEEex() {
 	initUncapFPS();
 
 	EEex::Opcode_LuaHook_AfterListsResolved_Enabled = false;
+	EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled = false;
 	EEex::Projectile_LuaHook_GlobalMutators_Enabled = false;
 	initProjectileMutator();
 	EEex::StutterDetector_Enabled = false;

--- a/EEex-v2.6.6.0/source/EEex-v2.6.6.0/Generated/Baldur-v2.6.6.0_generated_internal_pointers.cpp
+++ b/EEex-v2.6.6.0/source/EEex-v2.6.6.0/Generated/Baldur-v2.6.6.0_generated_internal_pointers.cpp
@@ -10,6 +10,7 @@ bool EEex::bStripUUID;
 byte EEex::CGameSprite_Hit_Roll;
 bool EEex::AIBase_LuaHook_OnEventTriggerSet_Enabled;
 bool EEex::Opcode_LuaHook_AfterListsResolved_Enabled;
+bool EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled;
 bool EEex::Projectile_LuaHook_GlobalMutators_Enabled;
 bool EEex::StutterDetector_Enabled;
 int EEex::UncapFPS_BusyWaitThreshold;

--- a/EEex-v2.6.6.0/source/EEex-v2.6.6.0/Generated/EEexLua_generated.cpp
+++ b/EEex-v2.6.6.0/source/EEex-v2.6.6.0/Generated/EEexLua_generated.cpp
@@ -39,6 +39,24 @@ static int tolua_get_EEex_reference_Opcode_LuaHook_AfterListsResolved_Enabled(lu
 	return 1;
 }
 
+static int tolua_get_EEex_Opcode_LuaHook_DeferredAfterListsResolved_Enabled(lua_State* L)
+{
+	tolua_pushboolean(L, (bool)EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled);
+	return 1;
+}
+
+static int tolua_set_EEex_Opcode_LuaHook_DeferredAfterListsResolved_Enabled(lua_State* L)
+{
+	EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled = tolua_setter_toboolean(L, "Opcode_LuaHook_DeferredAfterListsResolved_Enabled");
+	return 0;
+}
+
+static int tolua_get_EEex_reference_Opcode_LuaHook_DeferredAfterListsResolved_Enabled(lua_State* L)
+{
+	tolua_pushusertype(L, (void*)&EEex::Opcode_LuaHook_DeferredAfterListsResolved_Enabled, "Primitive<bool>");
+	return 1;
+}
+
 static int tolua_get_EEex_Projectile_LuaHook_GlobalMutators_Enabled(lua_State* L)
 {
 	tolua_pushboolean(L, (bool)EEex::Projectile_LuaHook_GlobalMutators_Enabled);
@@ -917,6 +935,8 @@ int OpenBindingsInternal(lua_State* L)
 		tolua_variable(L, "reference_AIBase_LuaHook_OnEventTriggerSet_Enabled", tolua_get_EEex_reference_AIBase_LuaHook_OnEventTriggerSet_Enabled, NULL);
 		tolua_variable(L, "Opcode_LuaHook_AfterListsResolved_Enabled", tolua_get_EEex_Opcode_LuaHook_AfterListsResolved_Enabled, tolua_set_EEex_Opcode_LuaHook_AfterListsResolved_Enabled);
 		tolua_variable(L, "reference_Opcode_LuaHook_AfterListsResolved_Enabled", tolua_get_EEex_reference_Opcode_LuaHook_AfterListsResolved_Enabled, NULL);
+		tolua_variable(L, "Opcode_LuaHook_DeferredAfterListsResolved_Enabled", tolua_get_EEex_Opcode_LuaHook_DeferredAfterListsResolved_Enabled, tolua_set_EEex_Opcode_LuaHook_DeferredAfterListsResolved_Enabled);
+		tolua_variable(L, "reference_Opcode_LuaHook_DeferredAfterListsResolved_Enabled", tolua_get_EEex_reference_Opcode_LuaHook_DeferredAfterListsResolved_Enabled, NULL);
 		tolua_variable(L, "Projectile_LuaHook_GlobalMutators_Enabled", tolua_get_EEex_Projectile_LuaHook_GlobalMutators_Enabled, tolua_set_EEex_Projectile_LuaHook_GlobalMutators_Enabled);
 		tolua_variable(L, "reference_Projectile_LuaHook_GlobalMutators_Enabled", tolua_get_EEex_reference_Projectile_LuaHook_GlobalMutators_Enabled, NULL);
 		tolua_variable(L, "StutterDetector_Enabled", tolua_get_EEex_StutterDetector_Enabled, tolua_set_EEex_StutterDetector_Enabled);
@@ -961,6 +981,7 @@ int OpenBindingsInternal(lua_State* L)
 		tolua_function(L, "UpdateLastScrollTime", &tolua_function_EEex_UpdateLastScrollTime);
 		tolua_constantstring(L, "usertype_AIBase_LuaHook_OnEventTriggerSet_Enabled", "Primitive<bool>");
 		tolua_constantstring(L, "usertype_Opcode_LuaHook_AfterListsResolved_Enabled", "Primitive<bool>");
+		tolua_constantstring(L, "usertype_Opcode_LuaHook_DeferredAfterListsResolved_Enabled", "Primitive<bool>");
 		tolua_constantstring(L, "usertype_Projectile_LuaHook_GlobalMutators_Enabled", "Primitive<bool>");
 		tolua_constantstring(L, "usertype_StutterDetector_Enabled", "Primitive<bool>");
 		tolua_constantstring(L, "usertype_UncapFPS_BusyWaitThreshold", "Primitive<int>");

--- a/EEex-v2.6.6.0/source/EEex-v2.6.6.0/main.cpp
+++ b/EEex-v2.6.6.0/source/EEex-v2.6.6.0/main.cpp
@@ -137,6 +137,7 @@ static void exportPatterns() {
 	exportPattern(TEXT("EEex::Opcode_Hook_ApplySpell_ShouldFlipSplprotSourceAndTarget"), EEex::Opcode_Hook_ApplySpell_ShouldFlipSplprotSourceAndTarget);
 	exportPattern(TEXT("EEex::Opcode_Hook_OnCheckAdd"), EEex::Opcode_Hook_OnCheckAdd);
 	exportPattern(TEXT("EEex::Opcode_Hook_AfterListsResolved"), EEex::Opcode_Hook_AfterListsResolved);
+	exportPattern(TEXT("EEex::Opcode_Hook_FlushDeferredAfterListsResolved"), EEex::Opcode_Hook_FlushDeferredAfterListsResolved);
 
 	////////////
 	// Sprite //


### PR DESCRIPTION
This PR implements an alternative listener to the existing `EEex_Opcode_AddListsResolvedListener()` (which is prone to cause stuttering / slowdowns under certain circumstances).

The new deferred listener fires:

- at most once per sprite `ProcessAI()` pass
- only if that sprite had one or more `ProcessEffectList()` resolutions since the previous flush
- never for temporary copied sprites that resolve lists but are destroyed before `ProcessAI()`
- independently from the legacy immediate listener, which still fires on every raw list resolution

So for one active sprite under normal 30 FPS / 15 AI-pass-per-second behavior: expect about 15 deferred callbacks per second max. For 20 active sprites, the upper bound is about `20 * 15` per second, but only for sprites that actually had pending resolved-list work.

See also: https://github.com/Bubb13/EEex/pull/129.